### PR TITLE
This commit closes #9

### DIFF
--- a/solution/src/app/Testeroids/Aspects/ProhibitGetOnNotInitializedPropertyAspectAttribute.cs
+++ b/solution/src/app/Testeroids/Aspects/ProhibitGetOnNotInitializedPropertyAspectAttribute.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ProhibitGetOnNotSetPropertyAspectAttribute.cs" company="Testeroids">
+// <copyright file="ProhibitGetOnNotInitializedPropertyAspectAttribute.cs" company="Testeroids">
 //   © 2012-2013 Testeroids. All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
@@ -23,7 +23,7 @@ namespace Testeroids.Aspects
     [MulticastAttributeUsage(MulticastTargets.Class, 
         TargetTypeAttributes = MulticastAttributes.AnyScope | MulticastAttributes.AnyVisibility | MulticastAttributes.NonAbstract | MulticastAttributes.Managed, 
         AllowMultiple = false, Inheritance = MulticastInheritance.Multicast)]
-    public class ProhibitGetOnNotSetPropertyAspectAttribute : InstanceLevelAspect
+    public class ProhibitGetOnNotInitializedPropertyAspectAttribute : InstanceLevelAspect
     {
         #region Public Properties
 
@@ -40,10 +40,10 @@ namespace Testeroids.Aspects
         /// <summary>
         /// Method invoked <i>instead</i> of the <c>Get</c> semantic of property to which the current aspect is applied,
         ///               i.e. when the value of this field or property is retrieved.
-        /// If the property's set method has not been called the method will throw an <see cref="PropertyNotSetException"/>.
+        /// If the property's set method has not been called the method will throw an <see cref="PropertyNotInitializedException"/>.
         /// </summary>
         /// <param name="args">Advice arguments.</param>
-        /// <exception cref="PropertyNotSetException">
+        /// <exception cref="PropertyNotInitializedException">
         /// When the property's set method has not been called before.
         /// </exception>
         [OnLocationGetValueAdvice]
@@ -53,7 +53,7 @@ namespace Testeroids.Aspects
             if (args.Location.PropertyInfo.GetSetMethod(true) != null
                 && !this.PropertySetList.Contains(args.LocationName))
             {
-                throw new PropertyNotSetException(args.LocationFullName);
+                throw new PropertyNotInitializedException(args.LocationFullName);
             }
 
             args.ProceedGetValue();

--- a/solution/src/app/Testeroids/ContextSpecificationBase.cs
+++ b/solution/src/app/Testeroids/ContextSpecificationBase.cs
@@ -23,7 +23,7 @@ namespace Testeroids
     /// <summary>
     ///   Base class for implementing the AAA pattern.
     /// </summary>
-    [ProhibitGetOnNotSetPropertyAspect]
+    [ProhibitGetOnNotInitializedPropertyAspect]
     public abstract class ContextSpecificationBase : IContextSpecification
     {
         #region Fields

--- a/solution/src/app/Testeroids/PropertyNotInitializedException.cs
+++ b/solution/src/app/Testeroids/PropertyNotInitializedException.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="PropertyNotSetException.cs" company="Testeroids">
+// <copyright file="PropertyNotInitializedException.cs" company="Testeroids">
 //   © 2012-2013 Testeroids. All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
@@ -10,18 +10,18 @@ namespace Testeroids
     /// <summary>
     /// Exception is thrown when code tries to call the get method on a property which has not been set
     /// </summary>
-    public class PropertyNotSetException : Exception
+    public class PropertyNotInitializedException : Exception
     {
         #region Constructors and Destructors
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PropertyNotSetException"/> class. 
+        /// Initializes a new instance of the <see cref="PropertyNotInitializedException"/> class. 
         /// </summary>
         /// <param name="propertyName">
         /// Full name of the property which hasn't been set before get was accessed
         /// </param>
-        public PropertyNotSetException(string propertyName)
-            : base("Property " + propertyName + "'s get method was accessed before the property was set")
+        public PropertyNotInitializedException(string propertyName)
+            : base("Property " + propertyName + "'s get method was called before the property was set")
         {
             this.PropertyName = propertyName;
         }

--- a/solution/src/app/Testeroids/Testeroids.csproj
+++ b/solution/src/app/Testeroids/Testeroids.csproj
@@ -98,7 +98,7 @@
     <Compile Include="Aspects\FailTestsOnAbstractClassesNonMarkedAbstractTestFixtureAspectAttribute.cs" />
     <Compile Include="Aspects\FailTestWithoutTestFixtureAspectAttribute.cs" />
     <Compile Include="Aspects\MakeEmptyTestsInconclusiveAspectAttribute.cs" />
-    <Compile Include="Aspects\ProhibitGetOnNotSetPropertyAspectAttribute.cs" />
+    <Compile Include="Aspects\ProhibitGetOnNotInitializedPropertyAspectAttribute.cs" />
     <Compile Include="Aspects\TypeInvestigationService.cs" />
     <Compile Include="Assert.cs" />
     <Compile Include="ContextSpecification.cs" />
@@ -121,7 +121,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="PropertyNotSetException.cs" />
+    <Compile Include="PropertyNotInitializedException.cs" />
     <Compile Include="RequiresPostSharp.cs" />
     <Compile Include="Rx\Aspects\RxContextAspectAttribute.cs" />
     <Compile Include="Rx\Aspects\RxTestSchedulerAspectAttribute.cs" />

--- a/solution/src/test/Testeroids.Tests/TestSpecs.cs
+++ b/solution/src/test/Testeroids.Tests/TestSpecs.cs
@@ -273,10 +273,10 @@ namespace Testeroids.Tests
                 #endregion
 
                 /// <summary>
-                /// Test that the <see cref="given_instantiated_Sut.with_ProhibitGetOnNotSetPropertyAspectAttribute.Because"/> method throws a <see cref="PropertyNotSetException"/>.
+                /// Test that the <see cref="given_instantiated_Sut.with_ProhibitGetOnNotSetPropertyAspectAttribute.Because"/> method throws a <see cref="PropertyNotInitializedException"/>.
                 /// </summary>
                 [Test]
-                [ExpectedException(typeof(PropertyNotSetException))]
+                [ExpectedException(typeof(PropertyNotInitializedException))]
                 public void then_PropertyNotSetException_is_thrown()
                 {
                 }


### PR DESCRIPTION
Added InstanceLevelAspect ProhibitGetOnNotSetPropertyAspectAttribute which verifies that no Get method is called on Property of a ContextSpecificationBase derived class without having used its Set method before.
