### PR TITLE
Issues with reference mscorlib 2.0.5

### DIFF
--- a/solution/src/app/Testeroids/Testeroids.csproj
+++ b/solution/src/app/Testeroids/Testeroids.csproj
@@ -40,8 +40,9 @@
     <AssemblyOriginatorKeyFile>..\..\..\Testeroids.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JetBrains.Annotations">
-      <HintPath>..\..\..\packages\JetBrains.Annotations.7.0\lib\net40\JetBrains.Annotations.dll</HintPath>
+    <Reference Include="JetBrains.Annotations, Version=7.1.0.0, Culture=neutral, PublicKeyToken=db26512813023263, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\JetBrains.Annotations.Redist.7.1\lib\net40\JetBrains.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Reactive.Testing, Version=2.1.30214.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/solution/src/app/Testeroids/packages.config
+++ b/solution/src/app/Testeroids/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JetBrains.Annotations" version="7.0" targetFramework="net40" />
+  <package id="JetBrains.Annotations.Redist" version="7.1" targetFramework="net40" />
   <package id="Moq.Testeroids" version="4.0.10819" targetFramework="net40" />
   <package id="NUnit" version="2.6.2" targetFramework="net40" />
   <package id="PostSharp" version="2.1.7.22" targetFramework="net40" />

--- a/solution/src/test/Testeroids.Tests/Testeroids.Tests.csproj
+++ b/solution/src/test/Testeroids.Tests/Testeroids.Tests.csproj
@@ -34,8 +34,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JetBrains.Annotations">
-      <HintPath>..\..\..\packages\JetBrains.Annotations.7.0\lib\net40\JetBrains.Annotations.dll</HintPath>
+    <Reference Include="JetBrains.Annotations, Version=7.1.0.0, Culture=neutral, PublicKeyToken=db26512813023263, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\JetBrains.Annotations.Redist.7.1\lib\net40\JetBrains.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.0.10818.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Moq.Testeroids.4.0.10819\lib\NET40\Moq.dll</HintPath>

--- a/solution/src/test/Testeroids.Tests/packages.config
+++ b/solution/src/test/Testeroids.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JetBrains.Annotations" version="7.0" targetFramework="net40" />
+  <package id="JetBrains.Annotations.Redist" version="7.1" targetFramework="net40" />
   <package id="Moq.Testeroids" version="4.0.10819" targetFramework="net40" />
   <package id="NUnit" version="2.6.2" targetFramework="net40" />
   <package id="PostSharp" version="2.1.7.22" targetFramework="net40" />


### PR DESCRIPTION
The package http://www.nuget.org/packages/JetBrains.Annotations/ used has a reference to mscorlib 2.0.5.

This gives problems on BuildServers which do not have every framework version installed.

Changed to JetBrains.Annotations.Redist.7.1 which references version 4.0
