### PR TITLE
Fixes issue with MakeEmptyTestsInconclusiveAspectAttribute

### DIFF
--- a/solution/src/app/Testeroids/Aspects/MakeEmptyTestsInconclusiveAspectAttribute.cs
+++ b/solution/src/app/Testeroids/Aspects/MakeEmptyTestsInconclusiveAspectAttribute.cs
@@ -99,9 +99,10 @@ namespace Testeroids.Aspects
 
             var selectEmptyTestMethods =
                 type.GetMethods(BindingFlags)
-                    .Where(info => (GetIntermediateLanguageFromMethodInfoBase(info).Count() <= 2) &&
-                                   info.IsDefined(typeof(TestAttribute), false) &&
-                                   !info.IsDefined(typeof(ExpectedExceptionAttribute), true));
+                    .Where(info => (!info.IsAbstract &&
+                                    info.IsDefined(typeof(TestAttribute), false) &&
+                                    !info.IsDefined(typeof(ExpectedExceptionAttribute), true) &&
+                                    GetIntermediateLanguageFromMethodInfoBase(info).Count() <= 2));
 
             return selectEmptyTestMethods;
         }


### PR DESCRIPTION
Do not analyze abstract methods in MakeEmptyTestsInconclusiveAspectAttribute
